### PR TITLE
Backport to Java 17 while requiring 21 to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 20
+          java-version: 21
           distribution: temurin
           cache: gradle
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 20
+          java-version: 21
           distribution: temurin
           cache: gradle
 

--- a/buildSrc/src/main/kotlin/warp.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/warp.library-conventions.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(20))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
     withJavadocJar()
     withSourcesJar()
@@ -82,6 +82,9 @@ tasks {
         classpath = configurations[acceptanceTest.runtimeClasspathConfigurationName] + acceptanceTest.output
 
         shouldRunAfter(tasks.test)
+    }
+    withType<JavaCompile> {
+        options.release.set(17)
     }
     javadoc {
         options {

--- a/warp/src/main/java/me/sparky983/warp/ConfigurationNode.java
+++ b/warp/src/main/java/me/sparky983/warp/ConfigurationNode.java
@@ -215,7 +215,7 @@ public interface ConfigurationNode {
    */
   @SafeVarargs
   static ConfigurationNode map(final Map.Entry<String, ConfigurationNode>... entries) {
-    final Map<String, ConfigurationNode> map = LinkedHashMap.newLinkedHashMap(entries.length);
+    final Map<String, ConfigurationNode> map = new LinkedHashMap<>();
     for (final Map.Entry<String, ConfigurationNode> entry : entries) {
       final String key = Objects.requireNonNull(entry.getKey()); // TODO: error message?
       final ConfigurationNode value = Objects.requireNonNull(entry.getValue());


### PR DESCRIPTION
Javadocs use `{@snippet}` which requires Java 20+.

https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/