### PR TITLE
Allow private configurations

### DIFF
--- a/warp/src/acceptanceTest/java/me/sparky983/warp/WarpTest.java
+++ b/warp/src/acceptanceTest/java/me/sparky983/warp/WarpTest.java
@@ -22,11 +22,6 @@ class WarpTest {
   }
 
   @Test
-  void testBuilder_NotPublic() {
-    assertThrows(IllegalArgumentException.class, () -> Warp.builder(Configurations.Private.class));
-  }
-
-  @Test
   void testBuilder_NotInterface() {
     assertThrows(IllegalArgumentException.class, () -> Warp.builder(Configurations.Class.class));
   }
@@ -90,6 +85,15 @@ class WarpTest {
         Warp.builder(Configurations.Empty.class);
 
     assertThrows(NullPointerException.class, () -> builder.source(null));
+  }
+
+  @Test
+  void testBuilder_NotPublic() throws ConfigurationException {
+    final Configurations.Private configuration = Warp.builder(Configurations.Private.class)
+        .source(ConfigurationSource.of(ConfigurationNode.map(Map.entry("property", ConfigurationNode.string("some string")))))
+        .build();
+
+    assertEquals("some string", configuration.property());
   }
 
   @Test

--- a/warp/src/acceptanceTest/java/me/sparky983/warp/WarpTest.java
+++ b/warp/src/acceptanceTest/java/me/sparky983/warp/WarpTest.java
@@ -89,9 +89,13 @@ class WarpTest {
 
   @Test
   void testBuilder_NotPublic() throws ConfigurationException {
-    final Configurations.Private configuration = Warp.builder(Configurations.Private.class)
-        .source(ConfigurationSource.of(ConfigurationNode.map(Map.entry("property", ConfigurationNode.string("some string")))))
-        .build();
+    final Configurations.Private configuration =
+        Warp.builder(Configurations.Private.class)
+            .source(
+                ConfigurationSource.of(
+                    ConfigurationNode.map(
+                        Map.entry("property", ConfigurationNode.string("some string")))))
+            .build();
 
     assertEquals("some string", configuration.property());
   }

--- a/warp/src/main/java/me/sparky983/warp/internal/schema/InterfaceSchema.java
+++ b/warp/src/main/java/me/sparky983/warp/internal/schema/InterfaceSchema.java
@@ -57,10 +57,6 @@ final class InterfaceSchema<T> implements Schema<T> {
       throw new IllegalArgumentException(configurationClass + " must be an interface");
     }
 
-    if (!Modifier.isPublic(configurationClass.getModifiers())) {
-      throw new IllegalArgumentException(configurationClass + " must be public");
-    }
-
     if (configurationClass.isSealed()) {
       throw new IllegalArgumentException(configurationClass + " must not be sealed");
     }

--- a/warp/src/testFixtures/java/me/sparky983/warp/Configurations.java
+++ b/warp/src/testFixtures/java/me/sparky983/warp/Configurations.java
@@ -10,7 +10,10 @@ public final class Configurations {
   public interface MissingAnnotation {}
 
   @Configuration
-  interface Private {}
+  interface Private {
+    @Property("property")
+    java.lang.String property();
+  }
 
   @Configuration
   public interface Hidden {}


### PR DESCRIPTION
When combined with #73 allows for this idiom to deserialize external types:

```java

final class DurationDeserializer implements Deserializer<Duration> {
  @Override
  public Renderer<Duration> deserialize(ConfigurationNode node, Deserializer.Context deserializerContext) throws DeserializationException {
    @Configuration
    private interface DurationConfiguration {
      @Property("unit")
      ChronoUnit unit();

      @Property("amount")
      int amount();
    }

    var renderer = deserializerContext.deserializer(DurationConfiguration.class)
        .orElseThrow()
        .deserialize(node, deserializerContext);
    return (rendererContext) -> {
      var duration = renderer.render(rendererContext);
      return Duration.of(duration.amount(), duration.unit());
    };
  }
}
```
