### PR TITLE
Clarify list indexes in error messages

### DIFF
--- a/warp/src/main/java/me/sparky983/warp/internal/deserializers/Deserializers.java
+++ b/warp/src/main/java/me/sparky983/warp/internal/deserializers/Deserializers.java
@@ -123,7 +123,7 @@ public final class Deserializers {
         try {
           renderers.add(elementDeserializer.deserialize(element, deserializerContext));
         } catch (final DeserializationException exception) {
-          listErrors.add(ConfigurationError.group(String.valueOf(i), exception.errors()));
+          listErrors.add(ConfigurationError.group("[" + i + "]", exception.errors()));
         }
       }
 

--- a/warp/src/test/java/me/sparky983/warp/internal/deserializers/ListDeserializerTest.java
+++ b/warp/src/test/java/me/sparky983/warp/internal/deserializers/ListDeserializerTest.java
@@ -79,8 +79,8 @@ class ListDeserializerTest {
 
     assertIterableEquals(
         List.of(
-            ConfigurationError.group("0", ConfigurationError.error("Must be an integer")),
-            ConfigurationError.group("2", ConfigurationError.error("Must be an integer"))),
+            ConfigurationError.group("[0]", ConfigurationError.error("Must be an integer")),
+            ConfigurationError.group("[2]", ConfigurationError.error("Must be an integer"))),
         thrown.errors());
     verifyNoMoreInteractions(validRenderer);
   }


### PR DESCRIPTION
Denote a list index with square brackets, to clarify that it's an element of a list for error message.